### PR TITLE
Add .vue extensions to vue components as VueJs now requiring them.

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -79,8 +79,8 @@
 
 <script setup>
 import {watchEffect, ref, inject} from "vue";
-    import Dropdown from "./components/Dropdown";
-    import Alert from "./components/Alert";
+    import Dropdown from "./components/Dropdown.vue";
+    import Alert from "./components/Alert.vue";
     import languages from "./lang"
 
     const props = defineProps({


### PR DESCRIPTION
Add component compatibility with Vite and new VueJs standard of requiring the .vue extension on view components for import. 